### PR TITLE
Improve readability: change note labels to white

### DIFF
--- a/src/ChordPalette/ChordPalette.css
+++ b/src/ChordPalette/ChordPalette.css
@@ -62,8 +62,9 @@
   margin-right: 10px;
   margin-bottom: 4px;
   opacity: 0.7;
-  background: linear-gradient(to right, #f0f0f0 0%, transparent 25%);
+  background: linear-gradient(to right, #000 0%, transparent 45%);
   padding-left: 3px;
+  color: #fff;
 }
 
 .chord-notes {
@@ -90,6 +91,7 @@
   margin: 0;
   padding: 0;
   min-width: 0;
+  color: #fff;
 }
 
 .search-container {

--- a/src/PianoBase/PianoBase.tsx
+++ b/src/PianoBase/PianoBase.tsx
@@ -101,7 +101,7 @@ const PianoBase = forwardRef<PianoBaseHandle, PianoBaseProps>(({
     const { pitches, duration, highlightGroup } = event;
     if (!pitches || pitches.length === 0 || !durationToMs) return;
 
-    console.log('Resaltando acorde:', pitches, 'con duración:', duration);
+    // console.log('Resaltando acorde:', pitches, 'con duración:', duration);
 
     pianoObservable?.notify({ type: "chordPlayed", chord: pitches });
 


### PR DESCRIPTION
This update improves accessibility and readability of chord note labels, especially when printing or using dark backgrounds.

- Changed note text color to white (#fff) in two CSS sections for better contrast.
- Adjusted background gradient to enhance legibility.
- Commented out an unnecessary console.log in PianoBase.tsx to keep the console clean.

Closes https://github.com/vyk2rr/piano-chords-cheat-sheet/issues/3

### before
<img width="221" height="326" alt="image" src="https://github.com/user-attachments/assets/f66e19ab-5270-4433-9103-413274381e16" />

### after
<img width="214" height="328" alt="image" src="https://github.com/user-attachments/assets/68b6c29f-706e-4f2c-9693-956c9ebcde2a" />


