### PR TITLE
Add Arpeggio/Chord toggle buttons with active styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,32 @@
 .piano-container {
   padding: 10px;
 }
+
+.play-mode-buttons {
+  padding: 10px;
+}
+
+.play-mode-buttons button {
+  padding: 0.6rem 1.2rem;
+  font-size: 1rem;
+  background-color: #e9ecef;
+  color: #495057;
+  border: 1px solid #ced4da;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.play-mode-buttons button:hover {
+  background-color: #dee2e6;
+}
+
+.play-mode-buttons button.active {
+  background-color: #4c6ef5;
+  color: white;
+  border: none;
+}
+
+.play-mode-buttons button.active:hover {
+  background-color: #3b5bdb;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,13 @@ import { useState } from "react";
 import PianoBase from "./PianoBase/PianoBase";
 import ChordPalette from "./ChordPalette/ChordPalette";
 import type { tChord } from "./PianoBase/PianoBase.types";
+import PlayModeToggle, { PlayMode } from './PlayModeToggle/PlayModeToggle.tsx';
 import "./App.css";
 
 function App() {
   const [currentChord, setCurrentChord] = useState<tChord>([]);
   const [currentColor, setCurrentColor] = useState<string>("#cccccc");
-  const [highlightPlayMode, setHighlightPlayMode] = useState<'chord' | 'arpeggio'>('chord');
+  const [highlightPlayMode, setHighlightPlayMode] = useState<PlayMode>('chord');
 
   return (
     <div>
@@ -15,20 +16,14 @@ function App() {
         <PianoBase highlightOnThePiano={currentChord} highlightPlayMode={highlightPlayMode} />
       </div>
 
-      <div className="play-mode-buttons">
-        <button
-          className={highlightPlayMode === 'arpeggio' ? 'active' : ''}
-          onClick={() => setHighlightPlayMode('arpeggio')}
-        >
-          Arpegio
-        </button>
-        <button
-          className={highlightPlayMode === 'chord' ? 'active' : ''}
-          onClick={() => setHighlightPlayMode('chord')}
-        >
-          Acorde
-        </button>
-      </div>
+      <PlayModeToggle
+        highlightPlayMode={highlightPlayMode}
+        setHighlightPlayMode={setHighlightPlayMode}
+      />
+
+      {/* // [INSPIRATION/REFERENCE ONLY]
+      // This block is intentionally left commented out for future UI ideas.
+      // Not used in current implementation. */}
 
       {/* {highlightPlayMode === 'arpeggio' ? (
         <div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,12 +7,57 @@ import "./App.css";
 function App() {
   const [currentChord, setCurrentChord] = useState<tChord>([]);
   const [currentColor, setCurrentColor] = useState<string>("#cccccc");
+  const [highlightPlayMode, setHighlightPlayMode] = useState<'chord' | 'arpeggio'>('chord');
 
   return (
     <div>
       <div style={{ background: currentColor }} className="piano-container">
-        <PianoBase highlightOnThePiano={currentChord} />
+        <PianoBase highlightOnThePiano={currentChord} highlightPlayMode={highlightPlayMode} />
       </div>
+
+      <div className="play-mode-buttons">
+        <button
+          className={highlightPlayMode === 'arpeggio' ? 'active' : ''}
+          onClick={() => setHighlightPlayMode('arpeggio')}
+        >
+          Arpegio
+        </button>
+        <button
+          className={highlightPlayMode === 'chord' ? 'active' : ''}
+          onClick={() => setHighlightPlayMode('chord')}
+        >
+          Acorde
+        </button>
+      </div>
+
+      {/* {highlightPlayMode === 'arpeggio' ? (
+        <div>
+          <label>
+            Duration:
+            <input type="number" step="0.1" defaultValue={0.5} />
+          </label>
+          <label>
+            Time:
+            <input type="number" step="0.1" defaultValue={0.1} />
+          </label>
+          <label>
+            Velocity:
+            <input type="number" step="0.1" min={0} max={1} defaultValue={0.7} />
+          </label>
+        </div>
+      ) : (
+        <div>
+          <label>
+            Duration:
+            <input type="number" step="0.1" defaultValue={0.5} />
+          </label>
+          <label>
+            Velocity:
+            <input type="number" step="0.1" min={0} max={1} defaultValue={0.7} />
+          </label>
+        </div>
+      )} */}
+
       <ChordPalette
         params={{
           currentChord,

--- a/src/PianoBase/PianoBase.tsx
+++ b/src/PianoBase/PianoBase.tsx
@@ -33,6 +33,7 @@ export interface PianoBaseProps {
   className?: string;
   renderUI?: (params: RenderUIParams) => React.ReactNode;
   createSynth?: () => SupportedSynthType;
+  highlightPlayMode?: 'chord' | 'arpeggio';
 }
 
 export type PianoBaseHandle = {
@@ -55,11 +56,12 @@ const PianoBase = forwardRef<PianoBaseHandle, PianoBaseProps>(({
   octave = 4,
   octaves = 3,
   highlightOnThePiano,
-  errorNotes = [], // Receive errorNotes
+  errorNotes = [],
   pianoObservable,
   className,
   renderUI,
   createSynth,
+  highlightPlayMode = 'arpeggio',
 }, ref) => {
   const { white, black } = generateNotes(octaves, octave);
 
@@ -89,13 +91,17 @@ const PianoBase = forwardRef<PianoBaseHandle, PianoBaseProps>(({
     if (highlightOnThePiano) {
       const chordArray = Array.isArray(highlightOnThePiano) ? highlightOnThePiano : [highlightOnThePiano];
 
-      playArpeggio(chordArray, "4n", "16n", 0.7);
+      if (highlightPlayMode === 'chord') {
+        playChord(chordArray, "4n", undefined, 0.7);
+      } else {
+        playArpeggio(chordArray, "4n", "16n", 0.7);
+      }
 
       chordArray.forEach(note => {
         highlightNoteInGroup(note, Infinity, 0);
       });
     }
-  }, [highlightOnThePiano, highlightNoteInGroup, clearGroupHighlights, playArpeggio]);
+  }, [highlightOnThePiano, highlightNoteInGroup, clearGroupHighlights, playArpeggio, playChord, highlightPlayMode]);
 
   const handleMelodyEvent = (event: iChordEvent) => {
     const { pitches, duration, highlightGroup } = event;

--- a/src/PlayModeToggle/PlayModeToggle.tsx
+++ b/src/PlayModeToggle/PlayModeToggle.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+export type PlayMode = 'chord' | 'arpeggio';
+
+export interface PlayModeToggleProps {
+  highlightPlayMode: PlayMode;
+  setHighlightPlayMode: React.Dispatch<React.SetStateAction<PlayMode>>;
+}
+
+const PlayModeToggle: React.FC<PlayModeToggleProps> = ({ highlightPlayMode, setHighlightPlayMode }) => (
+  <div className="play-mode-buttons">
+    <button
+      className={highlightPlayMode === 'arpeggio' ? 'active' : ''}
+      aria-pressed={highlightPlayMode === 'arpeggio'}
+      aria-label="Play mode: Arpegio"
+      onClick={() => setHighlightPlayMode('arpeggio')}
+    >
+      Arpegio
+    </button>
+    <button
+      className={highlightPlayMode === 'chord' ? 'active' : ''}
+      aria-pressed={highlightPlayMode === 'chord'}
+      aria-label="Play mode: Chord"
+      onClick={() => setHighlightPlayMode('chord')}
+    >
+      Acorde
+    </button>
+  </div>
+);
+
+export default PlayModeToggle;


### PR DESCRIPTION
This PR adds a play-mode toggle to the main App, letting users switch between “Arpegio” and “Acorde” playback when highlighting a chord:

closes https://github.com/vyk2rr/piano-chords-cheat-sheet/issues/7

### screenshot
<img width="383" height="499" alt="image" src="https://github.com/user-attachments/assets/25b93163-ed1b-4967-97f9-849b7711a80a" />
