### PR TITLE
Replace Vite icon with new piano SVG logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/icon.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Piano Chords Cheat Sheet</title>
   <meta property="og:title" content="Piano Chords Cheat Sheet" />

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,25 @@
+<svg viewBox="0 0 64 64" width="64" height="64" xmlns="http://www.w3.org/2000/svg">
+  <!-- Fondo con 3 teclas de Cmaj a todo alto -->
+  <rect x="0" y="0" width="21.33" height="64" fill="#ff4d4d" /> <!-- C -->
+  <rect x="21.33" y="0" width="21.34" height="64" fill="#ffeb3b" /> <!-- E -->
+  <rect x="42.67" y="0" width="21.33" height="64" fill="#00ccff" /> <!-- G -->
+
+  <!-- Piano base centrado con borde negro -->
+  <rect x="7" y="16" width="50" height="32" rx="6" fill="rgba(255, 255, 255, 0.2)" stroke="black" stroke-width="1.5" />
+
+  <!-- Teclas blancas -->
+  <rect x="9" y="18" width="6" height="28" fill="#ffffff" />
+  <rect x="16" y="18" width="6" height="28" fill="#ffffff" />
+  <rect x="23" y="18" width="6" height="28" fill="#ffffff" />
+  <rect x="30" y="18" width="6" height="28" fill="#ffffff" />
+  <rect x="37" y="18" width="6" height="28" fill="#ffffff" />
+  <rect x="44" y="18" width="6" height="28" fill="#ffffff" />
+  <rect x="51" y="18" width="6" height="28" fill="#ffffff" />
+
+  <!-- Teclas negras -->
+  <rect x="13" y="18" width="4" height="16" fill="#000000" rx="1" />
+  <rect x="20" y="18" width="4" height="16" fill="#000000" rx="1" />
+  <rect x="34" y="18" width="4" height="16" fill="#000000" rx="1" />
+  <rect x="41" y="18" width="4" height="16" fill="#000000" rx="1" />
+  <rect x="48" y="18" width="4" height="16" fill="#000000" rx="1" />
+</svg>

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,32 @@
 .piano-container {
   padding: 10px;
 }
+
+.play-mode-buttons {
+  padding: 10px;
+}
+
+.play-mode-buttons button {
+  padding: 0.6rem 1.2rem;
+  font-size: 1rem;
+  background-color: #e9ecef;
+  color: #495057;
+  border: 1px solid #ced4da;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.play-mode-buttons button:hover {
+  background-color: #dee2e6;
+}
+
+.play-mode-buttons button.active {
+  background-color: #4c6ef5;
+  color: white;
+  border: none;
+}
+
+.play-mode-buttons button.active:hover {
+  background-color: #3b5bdb;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,12 +7,57 @@ import "./App.css";
 function App() {
   const [currentChord, setCurrentChord] = useState<tChord>([]);
   const [currentColor, setCurrentColor] = useState<string>("#cccccc");
+  const [highlightPlayMode, setHighlightPlayMode] = useState<'chord' | 'arpeggio'>('chord');
 
   return (
     <div>
       <div style={{ background: currentColor }} className="piano-container">
-        <PianoBase highlightOnThePiano={currentChord} />
+        <PianoBase highlightOnThePiano={currentChord} highlightPlayMode={highlightPlayMode} />
       </div>
+
+      <div className="play-mode-buttons">
+        <button
+          className={highlightPlayMode === 'arpeggio' ? 'active' : ''}
+          onClick={() => setHighlightPlayMode('arpeggio')}
+        >
+          Arpegio
+        </button>
+        <button
+          className={highlightPlayMode === 'chord' ? 'active' : ''}
+          onClick={() => setHighlightPlayMode('chord')}
+        >
+          Acorde
+        </button>
+      </div>
+
+      {/* {highlightPlayMode === 'arpeggio' ? (
+        <div>
+          <label>
+            Duration:
+            <input type="number" step="0.1" defaultValue={0.5} />
+          </label>
+          <label>
+            Time:
+            <input type="number" step="0.1" defaultValue={0.1} />
+          </label>
+          <label>
+            Velocity:
+            <input type="number" step="0.1" min={0} max={1} defaultValue={0.7} />
+          </label>
+        </div>
+      ) : (
+        <div>
+          <label>
+            Duration:
+            <input type="number" step="0.1" defaultValue={0.5} />
+          </label>
+          <label>
+            Velocity:
+            <input type="number" step="0.1" min={0} max={1} defaultValue={0.7} />
+          </label>
+        </div>
+      )} */}
+
       <ChordPalette
         params={{
           currentChord,

--- a/src/PianoBase/PianoBase.tsx
+++ b/src/PianoBase/PianoBase.tsx
@@ -33,6 +33,7 @@ export interface PianoBaseProps {
   className?: string;
   renderUI?: (params: RenderUIParams) => React.ReactNode;
   createSynth?: () => SupportedSynthType;
+  highlightPlayMode?: 'chord' | 'arpeggio';
 }
 
 export type PianoBaseHandle = {
@@ -55,11 +56,12 @@ const PianoBase = forwardRef<PianoBaseHandle, PianoBaseProps>(({
   octave = 4,
   octaves = 3,
   highlightOnThePiano,
-  errorNotes = [], // Receive errorNotes
+  errorNotes = [],
   pianoObservable,
   className,
   renderUI,
   createSynth,
+  highlightPlayMode = 'arpeggio',
 }, ref) => {
   const { white, black } = generateNotes(octaves, octave);
 
@@ -89,13 +91,17 @@ const PianoBase = forwardRef<PianoBaseHandle, PianoBaseProps>(({
     if (highlightOnThePiano) {
       const chordArray = Array.isArray(highlightOnThePiano) ? highlightOnThePiano : [highlightOnThePiano];
 
-      playArpeggio(chordArray, "4n", "16n", 0.7);
+      if (highlightPlayMode === 'chord') {
+        playChord(chordArray, "4n", undefined, 0.7);
+      } else {
+        playArpeggio(chordArray, "4n", "16n", 0.7);
+      }
 
       chordArray.forEach(note => {
         highlightNoteInGroup(note, Infinity, 0);
       });
     }
-  }, [highlightOnThePiano, highlightNoteInGroup, clearGroupHighlights, playArpeggio]);
+  }, [highlightOnThePiano, highlightNoteInGroup, clearGroupHighlights, playArpeggio, playChord, highlightPlayMode]);
 
   const handleMelodyEvent = (event: iChordEvent) => {
     const { pitches, duration, highlightGroup } = event;


### PR DESCRIPTION
This PR introduces a custom SVG piano icon to replace the previous Vite logo. The new design visually represents a piano with clear white and black keys, and integrates a background illustrating a C major chord using vertical stripes in red, yellow, and sky blue.

Changes:
- Removed: vite.svg
- Added: icon.svg with custom piano + color-coded background

This makes the branding more musically relevant and aligned with the purpose of the app.

Closes https://github.com/vyk2rr/piano-chords-cheat-sheet/issues/9


### before 
<img width="92" height="34" alt="image" src="https://github.com/user-attachments/assets/ce6ff045-53c0-4402-83b7-65a5abedfbee" />

### after 
<img width="196" height="37" alt="image" src="https://github.com/user-attachments/assets/ccfb7a0a-bb66-42c6-aa33-816464457eeb" />
